### PR TITLE
Add command line option to change migration table name

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,19 +29,21 @@ import (
 )
 
 const (
-	flagNameProject       = "project"
-	flagNameInstance      = "instance"
-	flagNameDatabase      = "database"
-	flagNameDirectory     = "directory"
-	flagCredentialsFile   = "credentials_file"
-	flagNameSchemaFile    = "schema_file"
-	flagDDLFile           = "ddl"
-	flagDMLFile           = "dml"
-	flagPartitioned       = "partitioned"
-	flagPriority          = "priority"
-	flagNode              = "node"
-	flagTimeout           = "timeout"
-	defaultSchemaFileName = "schema.sql"
+	flagNameProject           = "project"
+	flagNameInstance          = "instance"
+	flagNameDatabase          = "database"
+	flagNameDirectory         = "directory"
+	flagCredentialsFile       = "credentials_file"
+	flagNameMigrationTable    = "migration_table"
+	flagNameSchemaFile        = "schema_file"
+	flagDDLFile               = "ddl"
+	flagDMLFile               = "dml"
+	flagPartitioned           = "partitioned"
+	flagPriority              = "priority"
+	flagNode                  = "node"
+	flagTimeout               = "timeout"
+	defaultSchemaFileName     = "schema.sql"
+	defaultMigrationTableName = "SchemaMigrations"
 )
 
 func newSpannerClient(ctx context.Context, c *cobra.Command) (*spanner.Client, error) {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -33,8 +33,7 @@ import (
 )
 
 const (
-	migrationsDirName  = "migrations"
-	migrationTableName = "SchemaMigrations"
+	migrationsDirName = "migrations"
 )
 
 // migrateCmd represents the migrate command
@@ -73,6 +72,7 @@ func init() {
 	)
 
 	migrateCmd.PersistentFlags().String(flagNameDirectory, "", "Directory that migration files placed (required)")
+	migrateCmd.PersistentFlags().String(flagNameMigrationTable, defaultMigrationTableName, "Name of migration table (optional)")
 }
 
 func migrateCreate(c *cobra.Command, args []string) error {
@@ -128,7 +128,7 @@ func migrateUp(c *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+	if err = client.EnsureMigrationTable(ctx, c.Flag(flagNameMigrationTable).Value.String()); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
@@ -144,7 +144,7 @@ func migrateUp(c *cobra.Command, args []string) error {
 		}
 	}
 
-	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName)
+	return client.ExecuteMigrations(ctx, migrations, limit, c.Flag(flagNameMigrationTable).Value.String())
 }
 
 func migrateVersion(c *cobra.Command, _ []string) error {
@@ -157,14 +157,14 @@ func migrateVersion(c *cobra.Command, _ []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+	if err = client.EnsureMigrationTable(ctx, c.Flag(flagNameMigrationTable).Value.String()); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
 		}
 	}
 
-	v, _, err := client.GetSchemaMigrationVersion(ctx, migrationTableName)
+	v, _, err := client.GetSchemaMigrationVersion(ctx, c.Flag(flagNameMigrationTable).Value.String())
 	if err != nil {
 		var se *spanner.Error
 		if errors.As(err, &se) && se.Code == spanner.ErrorCodeNoMigration {
@@ -206,14 +206,14 @@ func migrateSet(c *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+	if err = client.EnsureMigrationTable(ctx, c.Flag(flagNameMigrationTable).Value.String()); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
 		}
 	}
 
-	if err := client.SetSchemaMigrationVersion(ctx, uint(version), false, migrationTableName); err != nil {
+	if err := client.SetSchemaMigrationVersion(ctx, uint(version), false, c.Flag(flagNameMigrationTable).Value.String()); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

<!--
Write the change being made with this pull request
-->

Added command line option to change migration table name

## WHY

<!--
Write the motivation why you submit this pull request
-->

To specify table names arbitrarily according to system naming rules, etc.
